### PR TITLE
Added feature to allow restoring a file or directory 

### DIFF
--- a/BackUpAlice.install
+++ b/BackUpAlice.install
@@ -1,7 +1,7 @@
 {
     "name": "BackUpAlice",
     "speakableName": "Back up Alice",
-    "version": "1.1.12",
+    "version": "1.1.13",
     "icon": "fas fa-user-alien",
     "category": "organisation",
     "author": "Lazza",

--- a/config.json.template
+++ b/config.json.template
@@ -5,6 +5,19 @@
 		"isSensitive": false,
 		"category": "system",
 		"description": "Adds duration between back ups"
+	},
+	"pathOfRestoreFile": {
+		"defaultValue": "",
+		"dataType": "string",
+		"isSensitive": false,
+		"category": "system",
+		"description": "The file or directory you want to restore EG: skills/AliceVolume"
+	},
+	"enableFileRestore": {
+		"defaultValue": false,
+		"dataType": "boolean",
+		"isSensitive": false,
+		"category": "system",
+		"description": "Tells Alice you want to restore a file "
 	}
-
 }

--- a/instructions/en.md
+++ b/instructions/en.md
@@ -19,3 +19,21 @@ that's not really necessary unless its a initial back up, as she will do it auto
 
 However, if you want to force a back up, ask alice to "force a back up" and she will make a back up regardless
 of the date of the existing backup.
+
+### Restore feature
+
+There is now a option in the skills settings to restore a file or directory from a previous backup to your 
+current ProjectAlice folder. To achieve this ....
+
+- Open the skill's "settings" screen from the webUi
+- In the field called "path of restore file" add the path of the file or directory that you want to restore
+  - examples are
+    - skills/AliceVolume <-- This will be the whole AliceVolume Directory
+    - skills/Reminder/Sounds/Alarm/Alarm.wav <-- This will be the Alarm.wav from reminder skill
+    - config.json <-- This will be the config file from ~/ProjectAlice directory
+- Enable the "Enable File Restore" switch.
+
+Once "Enable File Restore" is enabled and you have a valid path written in "path of restore file" 
+within one minute you will see in the syslog that the copy process has happend from the backup directory 
+to the active ProjectAlice folder. It will then disable the "Enable File Restore" switch 
+(refresh UI to see the updated state). 


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
Added a feature to restore a file or directory from a existing backup. This saves the hassle of looking up what the backup directory is called then cd'ing into multiple directories etc .

To use this feature 
- Open the skill's "settings" screen from the webUi
- In the field called "path of restore file" add the path of the file or directory that you want to restore
  - examples are
    - skills/AliceVolume <-- This will be the whole AliceVolume Directory
    - skills/Reminder/Sounds/Alarm/Alarm.wav <-- This will be the Alarm.wav from reminder skill
    - config.json <-- This will be the config file from ~/ProjectAlice directory
- Enable the "Enable File Restore" switch.

Once "Enable File Restore" is enabled and you have a valid path written in "path of restore file" 
within one minute you will see in the syslog that the copy process has happend from the backup directory 
to the active ProjectAlice folder. It will then disable the "Enable File Restore" switch 
(refresh UI to see the updated state). 


<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
